### PR TITLE
store: flip a two-state switch on one detent

### DIFF
--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -6,6 +6,7 @@ import { countDetents } from '../seq/detent.js';
 import { moduleReadKey } from '../chain/config.js';
 import { concreteKey } from './pad-scope.js';
 import { enumRawToIndex, enumUsesIndex, enumSetValue } from './enum-value.js';
+import { isToggleParam } from './toggle.js';
 import { pageSlotMap } from './page-layout.js';
 import { inferGuessedMeta } from './meta-infer.js';
 import { applyTriggerDelta, seedTriggerState } from './trigger.js';
@@ -173,7 +174,18 @@ export function applyKnobDelta(s: ModelState, physK: number, delta: number): voi
     /* Snapshot the outgoing value in the same encoding the write uses, so the
      * inverse is byte-identical to what the DSP last received. */
     const prevNum = s.knobValues[gi] as number;
-    let newVal = prevNum + scaled;
+    /* A 2-state switch flips on ONE detent, in the direction turned.
+     *
+     * Without this it inherits the enum's fractional accumulator (delta/4 into
+     * a value clamped to [min,max], read back with Math.round), which on a
+     * boolean costs 2 detents to turn on and 3 to turn back off: from 0 the
+     * steps are .25 (rounds off) then .5 (rounds ON), while from 1 they are
+     * .75 and .5 (both still ON) before .25 finally reads off. That asymmetry
+     * contradicts the picture — we draw these as a switch precisely because
+     * the control has two states and no travel, so the knob should seat at the
+     * end you turned toward, immediately and idempotently. */
+    let newVal = isToggleParam(p) ? (delta > 0 ? p.max : p.min)
+                                  : prevNum + scaled;
     newVal = Math.max(p.min, Math.min(p.max, newVal));
     if (p.type === 'int') newVal = Math.round(newVal);
     // enum: store as float for fractional accumulation; read sites use Math.round


### PR DESCRIPTION
A boolean drawn as a switch takes 2 detents to turn on and 3 to turn back off, instead of 1 each way.

`isToggleParam` identifies these controls and `drawSwitch` renders them as a switch — two states, no travel — but the value still goes through the enum path in `applyKnobDelta`:

```js
const scaled = p.type === 'enum' ? delta / ENUM_DELTA_DIV : ...
let newVal = prevNum + scaled;
newVal = Math.max(p.min, Math.min(p.max, newVal));
```

On a `0..1` param that accumulates a quarter-step per detent and is read back with `Math.round`, which lands asymmetrically:

```
from 0:  .25 -> rounds off,  .5 -> rounds ON          (2 detents)
from 1:  .75 -> still ON,  .5 -> still ON,  .25 -> off (3 detents)
```

Measured with the real model before the change:

```
Tempo Sync OFF -> turning RIGHT:  detent 1: OFF   detent 2: ON
now ON -> turning LEFT:           detent 1: ON    detent 2: ON    detent 3: OFF
```

After: 1 detent each way, in the direction turned, and idempotent — holding the knob right keeps it on rather than toggling. Multi-option enums are untouched and keep the `ENUM_DELTA_DIV` click gate.

This only changes `isToggleParam` controls, i.e. exactly the set that already renders as a switch, so the feel matches the picture.

### Testing

`npm test` green: logic, dump-replay (79 modules), app-loop, 126 screenshot checks, perf, device-scripts.

Found while porting an audio-FX module to Schwung. Note the same class of bug exists in Schwung's vendored copy of this code (`src/shared/param_pages/movy_knob.mjs`), plus a second one there where `drawSwitch` reads the state with `Math.round(Number(raw))` and so never moves for a module reporting its enum by name — that one is specific to the port and is filed separately at charlesvestal/schwung#228. Movy's own renderer resolves the index correctly and is not affected.
