### PR TITLE
drums: address per-pad params by an explicit key table, not only a template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,45 @@ falling back to its bundled templates.
 > Prefer a module-owned layout when you also maintain that module; keep bundled
 > compatibility templates declarative and minimal.
 
+### Per-pad pages on a drum module
+
+A bank marked `"padSpecific": true` follows the pad you press. Its slots hold
+*alias* keys, and `drum.padScoping` says how an alias becomes the real key for
+the focused pad. There are two forms — use whichever matches how the module
+names its parameters:
+
+**Template** — when the pad number builds the key (sample players, voice-cloned
+engines). One rule covers every pad:
+
+```json
+"padScoping": {
+  "aliasPrefix": "pad_", "concreteKeyTemplate": "p{pad}_{suffix}", "padDigits": 2
+}
+```
+`pad_vol` on pad 3 → `p03_vol`.
+
+**Table** — when each voice is its own circuit and owns its parameter names, as
+on a TR-909/606-style machine. List each pad's key; `null` means that voice
+hasn't got that knob, and Movy shows the knob as unavailable rather than the
+previous pad's value:
+
+```json
+"padScoping": {
+  "aliasPrefix": "pad_",
+  "padKeys": {
+    "pitch": ["bd_c_tune", "sd_c_tune", "ohh_pitch"],
+    "drive": ["bd_c_drive", "sd_c_drive", null]
+  }
+}
+```
+`pad_pitch` on pad 3 → `ohh_pitch`.
+
+The table's keys are the module's **own declared parameters**, so they automate
+by their own name and need nothing extra in `chain_params` — unlike template
+keys, which are synthetic and validate through their alias. Both forms may
+appear in one config: the table wins where it lists a suffix, the template
+covers the rest.
+
 For modules whose releases Movy explicitly supports, copy the released
 `module.json` into `browser-test/fixtures/module-contracts/` using the
 `<component-type>--<module-id>.json` name. Contract fixtures replace an older

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -689,6 +689,11 @@ distortion and level are per-voice automatable, and the Noise page draws the
 noise filter's response curve. Each voice is addressed by a fixed index, so
 per-voice automation is playback-safe regardless of which pad last played.
 
+Per-pad pages are not only for sample players and voice-cloned engines:
+an **analog-style drum machine**, where every voice is its own circuit with its
+own knobs (a kick that has Sub and Tube, a sampled cymbal that has neither), can
+have one too — its layout lists each pad's parameters by name.
+
 Because there's no other way to choose a drum type on the device, drum modules
 rely on Movy's **layout templates**. Mr Drums, Weird Dreams, KrautDrums and
 Signal ship Movy templates; Forge and Libpo32 are **self-describing** — they

--- a/browser-test/dump-boot.mjs
+++ b/browser-test/dump-boot.mjs
@@ -172,7 +172,13 @@ export function expandLayoutKeys(layout) {
         if (sc && p.key.startsWith(sc.aliasPrefix)) {
             const suffix = p.key.slice(sc.aliasPrefix.length);
             for (let pad = 1; pad <= (layout.drum.padCount || 0); pad++) {
-                const padStr = String(pad).padStart(sc.padDigits, '0');
+                /* Both addressing forms: a listed per-pad key, else the
+                 * template. An unresolved alias (no key on this pad) adds
+                 * nothing — it reaches no native param by design. */
+                const listed = sc.padKeys?.[suffix]?.[pad - 1];
+                if (listed) { keys.add(listed); continue; }
+                if (listed === null || !sc.concreteKeyTemplate) continue;
+                const padStr = String(pad).padStart(sc.padDigits ?? 0, '0');
                 keys.add(sc.concreteKeyTemplate.replace('{pad}', padStr).replace('{suffix}', suffix));
             }
         }

--- a/browser-test/fixtures/9w9-movy-config.json
+++ b/browser-test/fixtures/9w9-movy-config.json
@@ -1,0 +1,581 @@
+{
+  "id": "9w9",
+  "name": "9W9",
+  "drum": {
+    "padCount": 11,
+    "padNoteStart": 36,
+    "rawMidi": false,
+    "padScoping": {
+      "aliasPrefix": "pad_",
+      "padKeys": {
+        "pitch": [
+          "bd_c_tune",
+          "sd_c_tune",
+          "lt_c_tune",
+          "mt_c_tune",
+          "ht_c_tune",
+          "rs_tune",
+          "hc_tune",
+          "ohh_pitch",
+          "ohh_pitch",
+          "cr_pitch",
+          "rc_pitch"
+        ],
+        "decay": [
+          "bd_c_decay",
+          "sd_c_decay",
+          "lt_c_decay",
+          "mt_c_decay",
+          "ht_c_decay",
+          "rs_decay",
+          "hc_decay",
+          "ohh_decay_closed",
+          "ohh_decay",
+          "cr_decay",
+          "rc_decay"
+        ],
+        "drive": [
+          "bd_c_drive",
+          "sd_c_drive",
+          "lt_c_drive",
+          "mt_c_drive",
+          "ht_c_drive",
+          "rs_saturation",
+          "hc_drive",
+          null,
+          null,
+          null,
+          null
+        ],
+        "dist": [
+          "bd_c_dist_type",
+          "sd_c_dist_type",
+          "lt_c_dist_type",
+          "mt_c_dist_type",
+          "ht_c_dist_type",
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "level": [
+          "bd_c_level",
+          "sd_c_level",
+          "lt_c_level",
+          "mt_c_level",
+          "ht_c_level",
+          "rs_volume",
+          "hc_volume",
+          "ohh_volume",
+          "ohh_volume",
+          "cr_volume",
+          "rc_volume"
+        ]
+      }
+    }
+  },
+  "banks": [
+    {
+      "name": "Voice",
+      "padSpecific": true,
+      "rows": [
+        [
+          {
+            "key": "pad_pitch",
+            "short": "PITCH",
+            "full": "Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "pad_decay",
+            "short": "DECAY",
+            "full": "Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "pad_drive",
+            "short": "DRIVE",
+            "full": "Drive",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "pad_dist",
+            "short": "DIST",
+            "full": "Distortion",
+            "type": "enum",
+            "options": [
+              "Diode",
+              "Clip",
+              "Fold",
+              "Crush"
+            ]
+          },
+          {
+            "key": "pad_level",
+            "short": "LEVEL",
+            "full": "Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          null,
+          null,
+          null
+        ]
+      ]
+    },
+    {
+      "name": "Kick",
+      "rows": [
+        [
+          {
+            "key": "bd_c_tune",
+            "short": "PITCH",
+            "full": "Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_sweep_depth",
+            "short": "PDEP",
+            "full": "P. Depth",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_sweep_time",
+            "short": "TUNE",
+            "full": "Tune",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_attack",
+            "short": "ATTK",
+            "full": "Attack",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_decay",
+            "short": "DECAY",
+            "full": "Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_drive",
+            "short": "DRIVE",
+            "full": "Drive",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_sub",
+            "short": "SUB",
+            "full": "Sub",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_level",
+            "short": "LEVEL",
+            "full": "Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          }
+        ],
+        [
+          {
+            "key": "bd_c_tube",
+            "short": "TUBE",
+            "full": "Tube",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_drift",
+            "short": "DRIFT",
+            "full": "Drift",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_click_tone",
+            "short": "CLICK",
+            "full": "Click Tone",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "bd_c_dist_type",
+            "short": "DIST",
+            "full": "Distortion",
+            "type": "enum",
+            "options": [
+              "Diode",
+              "Clip",
+              "Fold",
+              "Crush"
+            ]
+          },
+          null,
+          null,
+          null,
+          null
+        ]
+      ]
+    },
+    {
+      "name": "Snare",
+      "rows": [
+        [
+          {
+            "key": "sd_c_tune",
+            "short": "PITCH",
+            "full": "Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_sweep_depth",
+            "short": "PDEP",
+            "full": "P. Depth",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_snappy",
+            "short": "SNAPY",
+            "full": "Snappy",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_noise_decay",
+            "short": "SNDCY",
+            "full": "Sn Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_decay",
+            "short": "DECAY",
+            "full": "Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_drive",
+            "short": "DRIVE",
+            "full": "Drive",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_tune2",
+            "short": "SHEL2",
+            "full": "Shell 2",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "sd_c_level",
+            "short": "LEVEL",
+            "full": "Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Toms",
+      "rows": [
+        [
+          {
+            "key": "lt_c_tune",
+            "short": "LTPCH",
+            "full": "Low Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "lt_c_decay",
+            "short": "LTDCY",
+            "full": "Low Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "mt_c_tune",
+            "short": "MTPCH",
+            "full": "Mid Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "mt_c_decay",
+            "short": "MTDCY",
+            "full": "Mid Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "ht_c_tune",
+            "short": "HTPCH",
+            "full": "Hi Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "ht_c_decay",
+            "short": "HTDCY",
+            "full": "Hi Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "lt_c_level",
+            "short": "LTLVL",
+            "full": "Low Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "ht_c_level",
+            "short": "HTLVL",
+            "full": "Hi Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Perc",
+      "rows": [
+        [
+          {
+            "key": "rs_tune",
+            "short": "RMPCH",
+            "full": "Rim Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "rs_decay",
+            "short": "RMDCY",
+            "full": "Rim Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "rs_volume",
+            "short": "RMLVL",
+            "full": "Rim Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "hc_tune",
+            "short": "CPPCH",
+            "full": "Clap Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "hc_spread",
+            "short": "CPSPR",
+            "full": "Clap Sprd",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "hc_decay",
+            "short": "CPTL",
+            "full": "Clap Tail",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "hc_drive",
+            "short": "CPDRV",
+            "full": "Clap Drive",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "hc_volume",
+            "short": "CPLVL",
+            "full": "Clap Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Hats",
+      "rows": [
+        [
+          {
+            "key": "ohh_decay",
+            "short": "OPDCY",
+            "full": "Open Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "ohh_decay_closed",
+            "short": "CLDCY",
+            "full": "Closed Dcy",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "ohh_pitch",
+            "short": "HHPCH",
+            "full": "Hat Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "ohh_volume",
+            "short": "HHLVL",
+            "full": "Hat Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "rc_decay",
+            "short": "RDDCY",
+            "full": "Ride Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "rc_volume",
+            "short": "RDLVL",
+            "full": "Ride Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "cr_decay",
+            "short": "CRDCY",
+            "full": "Crash Decay",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "cr_volume",
+            "short": "CRLVL",
+            "full": "Crash Level",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Master",
+      "rows": [
+        [
+          {
+            "key": "master_dist",
+            "short": "MDIST",
+            "full": "Master Dist",
+            "type": "enum",
+            "options": [
+              "Off",
+              "Diode",
+              "Clip",
+              "Fold",
+              "Crush"
+            ]
+          },
+          {
+            "key": "master_drive",
+            "short": "MDRV",
+            "full": "Master Drive",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "volume",
+            "short": "VOL",
+            "full": "Volume",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "accent",
+            "short": "ACNT",
+            "full": "Accent",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          null,
+          null,
+          null,
+          null
+        ]
+      ]
+    }
+  ]
+}

--- a/browser-test/fixtures/9w9-movy-config.json
+++ b/browser-test/fixtures/9w9-movy-config.json
@@ -21,6 +21,19 @@
           "cr_pitch",
           "rc_pitch"
         ],
+        "pdepth": [
+          "bd_c_sweep_depth",
+          "sd_c_sweep_depth",
+          "lt_c_sweep_depth",
+          "mt_c_sweep_depth",
+          "ht_c_sweep_depth",
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
         "decay": [
           "bd_c_decay",
           "sd_c_decay",
@@ -42,10 +55,10 @@
           "ht_c_drive",
           "rs_saturation",
           "hc_drive",
-          null,
-          null,
-          null,
-          null
+          "ohh_drive",
+          "ohh_drive",
+          "cr_drive",
+          "rc_drive"
         ],
         "dist": [
           "bd_c_dist_type",
@@ -53,12 +66,12 @@
           "lt_c_dist_type",
           "mt_c_dist_type",
           "ht_c_dist_type",
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          "rs_dist_type",
+          "hc_dist_type",
+          "ohh_dist_type",
+          "ohh_dist_type",
+          "cr_dist_type",
+          "rc_dist_type"
         ],
         "level": [
           "bd_c_level",
@@ -86,6 +99,14 @@
             "key": "pad_pitch",
             "short": "PITCH",
             "full": "Pitch",
+            "type": "int",
+            "min": 0,
+            "max": 127
+          },
+          {
+            "key": "pad_pdepth",
+            "short": "PDEP",
+            "full": "Pitch Depth",
             "type": "int",
             "min": 0,
             "max": 127
@@ -126,7 +147,6 @@
             "min": 0,
             "max": 127
           },
-          null,
           null,
           null
         ]

--- a/browser-test/logic/automation.mjs
+++ b/browser-test/logic/automation.mjs
@@ -405,6 +405,12 @@ _log('\npad-scope aliasFromConcrete:');
     eq('override concrete → alias', aliasFromConcrete(ov, 'v3_fx1'), 'cv_fx1');
     eq('foreign key sharing shape → null', aliasFromConcrete(ov, 'v3_lvl'), null);
     eq('main template still maps', aliasFromConcrete(ov, 'pv3_pwm'), 'cv_pwm');
+    /* padKeys entries are the module's OWN declared params, so they are NOT
+     * reverse-mapped: bd_c_tune validates as itself. Aliasing it to pad_pitch —
+     * a key 9W9 never declares — would purge every per-voice lane as stale. */
+    const tbl = { aliasPrefix: 'pad_', padKeys: { pitch: ['bd_c_tune', 'sd_c_tune'] } };
+    eq('padKeys key not reverse-mapped', aliasFromConcrete(tbl, 'bd_c_tune'), null);
+    eq('padKeys-only config, foreign key → null', aliasFromConcrete(tbl, 'p07_pan'), null);
 }
 
 /* ── automation: lane validation (purge stale / obsolete-alias lanes) ─────── */
@@ -438,6 +444,14 @@ _log('\nautomation validateLane:');
     eq('override send lane kept', validateLane('synth:v3_fx1', ovPs, ovLookup).max, 1);
     eq('direct concrete param kept', validateLane('synth:v3_lvl', ovPs, ovLookup).max, 1);
     eq('stale override-shaped lane dropped', validateLane('synth:v3_zzz', ovPs, ovLookup), 'drop');
+    // padKeys: the per-voice key is declared by the module, so its lane keeps
+    // its own range; the alias itself is still an obsolete lane target.
+    const tblPs = { aliasPrefix: 'pad_', padKeys: { pitch: ['bd_c_tune', 'sd_c_tune'] } };
+    const tblMeta = { bd_c_tune: { min: 0, max: 127, type: 'int' } };
+    const tblLookup = (k) => tblMeta[k] ?? null;
+    eq('per-voice lane kept', validateLane('synth:bd_c_tune', tblPs, tblLookup).max, 127);
+    eq('alias lane dropped', validateLane('synth:pad_pitch', tblPs, tblLookup), 'drop');
+    eq('undeclared voice key dropped', validateLane('synth:zz_c_tune', tblPs, tblLookup), 'drop');
 }
 
 /* ── automation: chain-mapping verify/re-apply after a module reload ──────── */

--- a/browser-test/logic/drums.mjs
+++ b/browser-test/logic/drums.mjs
@@ -438,7 +438,8 @@ _log('\nTest: 9w9 padKeys per-pad addressing');
 
   const at = (key) => [0, 1, 2, 3, 4, 5, 6, 7]
       .find((k) => nw.getKnobParamInfo(k)?.key === key);
-  const pitch = at('pad_pitch'), decay = at('pad_decay'), drive = at('pad_drive');
+  const pitch = at('pad_pitch'), decay = at('pad_decay'), drive = at('pad_drive'),
+        pdepth = at('pad_pdepth');
   eq('Voice bank knobs are on page 0', pitch !== undefined && decay !== undefined, true);
 
   // Pad 1 = kick: the alias resolves to the kick circuit's own param.
@@ -472,23 +473,26 @@ _log('\nTest: 9w9 padKeys per-pad addressing');
   eq('pad 9 decay value', nw.getKnobParamInfo(decay).value, 91);
   eq('pad 9 pitch shares the voice key', nw.getKnobParamInfo(pitch).ioKey, 'ohh_pitch');
 
-  // The sampled hat has no Drive: unavailable, inert, and no automation dot —
-  // rather than showing the kick's value and writing to a key that isn't there.
+  eq('pad 9 drive → ohh_drive', nw.getKnobParamInfo(drive).ioKey, 'ohh_drive');
+
+  // The hat has no pitch envelope, so Pitch Depth is listed as null for it:
+  // unavailable, inert, and no automation dot — rather than showing the kick's
+  // value and writing to a key this voice hasn't got.
   const cell = (k) => { const vm2 = nw.getViewModel();
       return vm2.rows[Math.floor(k / 4)]?.[k % 4]; };
-  eq('absent drive reads as unavailable', cell(drive)?.displayValue, '...');
-  eq('absent drive not automatable', nw.getKnobParamInfo(drive).automatable, false);
+  eq('absent P.Depth reads as unavailable', cell(pdepth)?.displayValue, '...');
+  eq('absent P.Depth not automatable', nw.getKnobParamInfo(pdepth).automatable, false);
   const seen2 = [];
   globalThis.shadow_set_param = (sl, k, v) => { seen2.push(k); return origSet(sl, k, v); };
-  nw.handleKnobDelta(drive, 6);
+  nw.handleKnobDelta(pdepth, 6);
   nw.tick();
   globalThis.shadow_set_param = origSet;
-  eq('absent drive writes nothing', seen2.length, 0);
+  eq('absent P.Depth writes nothing', seen2.length, 0);
 
   // Back to a voice that has it: the knob comes alive again.
   nw.updateDrumPad(1, 68);
-  eq('drive live again on pad 1', nw.getKnobParamInfo(drive).value, 12);
-  eq('drive displays again on pad 1', cell(drive)?.displayValue, '12');
+  eq('P.Depth live again on pad 1', nw.getKnobParamInfo(pdepth).ioKey, 'bd_c_sweep_depth');
+  eq('P.Depth displays again on pad 1', cell(pdepth)?.displayValue, '14');
 }
 
 /* ── drumPadOn / drumPadOff ──────────────────────────────────────────────── */

--- a/browser-test/logic/drums.mjs
+++ b/browser-test/logic/drums.mjs
@@ -6,7 +6,7 @@
 
 import {
     MOCK_SYNTHS, drumPadOn, drumPadOff, fail, eq, bootModel,
-    _log, env, mockFsEntries,
+    _log, env, mockFsEntries, readFileSync,
 } from './harness.mjs';
 
 export async function run() {
@@ -337,6 +337,26 @@ _log('\nTest: pad-scope concreteKey');
   eq('override within maxPad', concreteKey(ov, 3, 'cv_fx1'), 'v3_fx1');
   eq('override past maxPad → main', concreteKey(ov, 9, 'cv_fx1'), 'pv9_fx1');
   eq('non-override suffix → main', concreteKey(ov, 3, 'cv_wave'), 'pv3_wave');
+
+  /* padKeys: voices named after the circuit, not the pad number. */
+  const tbl = { aliasPrefix: 'pad_', padKeys: { pitch: ['bd_c_tune', 'sd_c_tune', null] } };
+  eq('table pad 1', concreteKey(tbl, 1, 'pad_pitch'), 'bd_c_tune');
+  eq('table pad 2', concreteKey(tbl, 2, 'pad_pitch'), 'sd_c_tune');
+  // A listed null means "this voice has no such knob" → alias stays unresolved.
+  eq('listed null → unresolved', concreteKey(tbl, 3, 'pad_pitch'), 'pad_pitch');
+  eq('pad past list, no template → unresolved', concreteKey(tbl, 9, 'pad_pitch'), 'pad_pitch');
+  eq('unlisted suffix, no template → unresolved', concreteKey(tbl, 1, 'pad_decay'), 'pad_decay');
+  eq('non-alias passthrough', concreteKey(tbl, 1, 'master_drive'), 'master_drive');
+
+  // Both forms in one config: the table wins where it speaks, the template
+  // covers the rest — so a module can list its odd voices and template the rest.
+  const both = {
+    aliasPrefix: 'pad_', concreteKeyTemplate: 'p{pad}_{suffix}', padDigits: 2,
+    padKeys: { pitch: ['bd_c_tune'] },
+  };
+  eq('table wins over template', concreteKey(both, 1, 'pad_pitch'), 'bd_c_tune');
+  eq('past table end → template', concreteKey(both, 3, 'pad_pitch'), 'p03_pitch');
+  eq('unlisted suffix → template', concreteKey(both, 3, 'pad_vol'), 'p03_vol');
 }
 
 /* ── Mr Drums: focused-pad scoping ───────────────────────────────────────── */
@@ -398,6 +418,77 @@ _log('\nTest: weird-dreams per-voice scoping');
   eq('focus moved to voice 3', wd.getViewModel().drumCurrentPad, 3);
   eq('VOL re-read for v3 (0.33)', wd.getKnobParamInfo(0).value, 0.33);
   eq('ioKey follows focus to v3_vol', wd.getKnobParamInfo(0).ioKey, 'v3_vol');
+}
+
+/* ── 9W9: per-voice keys via padKeys ─────────────────────────────────────── */
+
+_log('\nTest: 9w9 padKeys per-pad addressing');
+{
+  /* 9W9 ships its own movy_config.json (canonical: athousanddetails/schwung-9W9,
+   * src/movy_config.json); serve the fixture snapshot the way module-configs
+   * does, since the logic harness stubs host_read_file to null. */
+  const savedRead = globalThis.host_read_file;
+  const layout = readFileSync(new URL('../fixtures/9w9-movy-config.json', import.meta.url), 'utf8');
+  globalThis.host_read_file = (p) => p.endsWith('/9w9/movy_config.json') ? layout : null;
+  const nw = bootModel(MOCK_SYNTHS.nw9, 0, 'synth');
+  globalThis.host_read_file = savedRead;
+  const vm = nw.getViewModel();
+  eq('9w9 is a drum module', vm.drumPadCount, 11);
+  eq('Voice bank is pad-specific', vm.isPadSpecific, true);
+
+  const at = (key) => [0, 1, 2, 3, 4, 5, 6, 7]
+      .find((k) => nw.getKnobParamInfo(k)?.key === key);
+  const pitch = at('pad_pitch'), decay = at('pad_decay'), drive = at('pad_drive');
+  eq('Voice bank knobs are on page 0', pitch !== undefined && decay !== undefined, true);
+
+  // Pad 1 = kick: the alias resolves to the kick circuit's own param.
+  eq('pad 1 pitch → bd_c_tune', nw.getKnobParamInfo(pitch).ioKey, 'bd_c_tune');
+  eq('pad 1 pitch value', nw.getKnobParamInfo(pitch).value, 10);
+  eq('pad 1 drive → bd_c_drive', nw.getKnobParamInfo(drive).ioKey, 'bd_c_drive');
+  eq('pad 1 drive automatable', nw.getKnobParamInfo(drive).automatable, true);
+
+  // A turn writes the voice's key — never the alias, which no DSP would accept.
+  const seen = [];
+  const origSet = globalThis.shadow_set_param;
+  globalThis.shadow_set_param = (sl, k, v) => { seen.push(k); return origSet(sl, k, v); };
+  nw.handleKnobDelta(pitch, 4);
+  nw.tick();
+  globalThis.shadow_set_param = origSet;
+  eq('edit writes bd_c_tune', seen.includes('synth:bd_c_tune'), true);
+  eq('edit never writes the alias', seen.includes('synth:pad_pitch'), false);
+
+  // Pad 2 = snare: same knob, a different circuit's key and value.
+  nw.updateDrumPad(2, 69);
+  eq('pad 2 pitch → sd_c_tune', nw.getKnobParamInfo(pitch).ioKey, 'sd_c_tune');
+  eq('pad 2 pitch value re-read', nw.getKnobParamInfo(pitch).value, 20);
+
+  // Pads 8 and 9 are ONE circuit with two decay knobs (closed / open hat) —
+  // the mapping a pad-number template cannot express in any form.
+  nw.updateDrumPad(8, 79);
+  eq('pad 8 decay → ohh_decay_closed', nw.getKnobParamInfo(decay).ioKey, 'ohh_decay_closed');
+  eq('pad 8 decay value', nw.getKnobParamInfo(decay).value, 81);
+  nw.updateDrumPad(9, 84);
+  eq('pad 9 decay → ohh_decay (same voice)', nw.getKnobParamInfo(decay).ioKey, 'ohh_decay');
+  eq('pad 9 decay value', nw.getKnobParamInfo(decay).value, 91);
+  eq('pad 9 pitch shares the voice key', nw.getKnobParamInfo(pitch).ioKey, 'ohh_pitch');
+
+  // The sampled hat has no Drive: unavailable, inert, and no automation dot —
+  // rather than showing the kick's value and writing to a key that isn't there.
+  const cell = (k) => { const vm2 = nw.getViewModel();
+      return vm2.rows[Math.floor(k / 4)]?.[k % 4]; };
+  eq('absent drive reads as unavailable', cell(drive)?.displayValue, '...');
+  eq('absent drive not automatable', nw.getKnobParamInfo(drive).automatable, false);
+  const seen2 = [];
+  globalThis.shadow_set_param = (sl, k, v) => { seen2.push(k); return origSet(sl, k, v); };
+  nw.handleKnobDelta(drive, 6);
+  nw.tick();
+  globalThis.shadow_set_param = origSet;
+  eq('absent drive writes nothing', seen2.length, 0);
+
+  // Back to a voice that has it: the knob comes alive again.
+  nw.updateDrumPad(1, 68);
+  eq('drive live again on pad 1', nw.getKnobParamInfo(drive).value, 12);
+  eq('drive displays again on pad 1', cell(drive)?.displayValue, '12');
 }
 
 /* ── drumPadOn / drumPadOff ──────────────────────────────────────────────── */

--- a/browser-test/mock-synth.mjs
+++ b/browser-test/mock-synth.mjs
@@ -1054,6 +1054,33 @@ export const MOCK_SYNTHS = {
         "synth:vol":    "0.8",
     },
 
+    /* 9W9 (TR-909 style): one circuit per voice, so params are named after the
+     * VOICE (bd_c_tune, ohh_pitch) and the sampled cymbals have no Drive or
+     * Distortion at all. Nothing a {pad}-number template can address — this is
+     * the module the padKeys form exists for. Values differ per voice so a test
+     * can prove which key a knob actually reached. */
+    nw9: {
+        "synth:name":           "9W9",
+        "synth_module":         "9w9",
+        "synth:chain_params": JSON.stringify([
+            { key: "bd_c_dist_type", name: "Distortion", type: "enum",
+              options: ["Diode (909)", "Hard Clip", "Wavefolder", "Bitcrush"] },
+        ]),
+        "synth:bd_c_tune":      "10",
+        "synth:bd_c_decay":     "11",
+        "synth:bd_c_drive":     "12",
+        "synth:bd_c_dist_type": "Hard Clip",
+        "synth:bd_c_level":     "13",
+        "synth:sd_c_tune":      "20",
+        "synth:sd_c_decay":     "21",
+        /* Pads 8 and 9 are the same hi-hat circuit with two decay knobs — the
+         * case a per-pad template cannot express at all. */
+        "synth:ohh_pitch":         "80",
+        "synth:ohh_decay_closed":  "81",
+        "synth:ohh_decay":         "91",
+        "synth:ohh_volume":        "82",
+    },
+
     mrdrums: {
         "synth:name":             "MrDrums",
         "synth_module":           "mrdrums",

--- a/browser-test/mock-synth.mjs
+++ b/browser-test/mock-synth.mjs
@@ -1058,7 +1058,8 @@ export const MOCK_SYNTHS = {
      * VOICE (bd_c_tune, ohh_pitch) and the sampled cymbals have no Drive or
      * Distortion at all. Nothing a {pad}-number template can address — this is
      * the module the padKeys form exists for. Values differ per voice so a test
-     * can prove which key a knob actually reached. */
+     * can prove which key a knob actually reached. The hi-hat has Drive but no
+     * pitch-envelope depth — only the five circuit voices have one. */
     nw9: {
         "synth:name":           "9W9",
         "synth_module":         "9w9",
@@ -1067,6 +1068,7 @@ export const MOCK_SYNTHS = {
               options: ["Diode (909)", "Hard Clip", "Wavefolder", "Bitcrush"] },
         ]),
         "synth:bd_c_tune":      "10",
+        "synth:bd_c_sweep_depth": "14",
         "synth:bd_c_decay":     "11",
         "synth:bd_c_drive":     "12",
         "synth:bd_c_dist_type": "Hard Clip",
@@ -1079,6 +1081,7 @@ export const MOCK_SYNTHS = {
         "synth:ohh_decay_closed":  "81",
         "synth:ohh_decay":         "91",
         "synth:ohh_volume":        "82",
+        "synth:ohh_drive":         "83",
     },
 
     mrdrums: {

--- a/src/model/pad-scope.ts
+++ b/src/model/pad-scope.ts
@@ -6,7 +6,8 @@ const escRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /* Anchored matcher for a concrete-key template; `suffixPat` is a regex fragment
  * for the {suffix} position ("(.+)" to capture any, or an escaped literal). */
-function templateRegex(tpl: string, padDigits: number, suffixPat: string): RegExp | null {
+function templateRegex(tpl: string | undefined, padDigits: number | undefined, suffixPat: string): RegExp | null {
+    if (!tpl || padDigits === undefined) return null;   // padKeys-only config
     const padIdx = tpl.indexOf('{pad}');
     const sufIdx = tpl.indexOf('{suffix}');
     if (padIdx < 0 || sufIdx < 0) return null;
@@ -25,10 +26,24 @@ function templateRegex(tpl: string, padDigits: number, suffixPat: string): RegEx
 export function concreteKey(ps: PadScoping | undefined, pad: number, key: string): string {
     if (!ps || !key.startsWith(ps.aliasPrefix)) return key;
     const suffix = key.slice(ps.aliasPrefix.length);
+    /* An explicit per-pad key wins over any template: a module whose voices are
+     * separate circuits names its params after the VOICE (bd_c_tune, ohh_pitch),
+     * which no pad-number template can produce. See DrumConfig.padScoping. */
+    const table = ps.padKeys?.[suffix];
+    if (table && pad - 1 < table.length) {
+        /* A listed null is a decision, not a gap: this voice has no such knob,
+         * so the alias stays unresolved and the caller renders it unavailable.
+         * Falling back to the template here would address a key the module
+         * never had. */
+        return table[pad - 1] ?? key;
+    }
     const o = ps.suffixOverrides?.[suffix];
     const tpl = (o && (o.maxPad === undefined || pad <= o.maxPad))
         ? o.template : ps.concreteKeyTemplate;
-    const padStr = String(pad).padStart(ps.padDigits, '0');
+    /* No template configured (a padKeys-only module, pad past the list): leave
+     * the alias as-is — unavailable beats addressing another pad's param. */
+    if (!tpl) return key;
+    const padStr = String(pad).padStart(ps.padDigits ?? 0, '0');
     return tpl.replace('{pad}', padStr).replace('{suffix}', suffix);
 }
 
@@ -39,7 +54,14 @@ export function concreteKey(ps: PadScoping | undefined, pad: number, key: string
  * THAT exists — the concrete key itself is never listed. Assumes the template
  * places {pad} before {suffix} (true for every config). An override template is
  * matched only against its own literal suffix, so foreign keys sharing the
- * shape (v3_lvl vs the fx1 override) can't false-match. */
+ * shape (v3_lvl vs the fx1 override) can't false-match.
+ *
+ * padKeys entries are deliberately NOT reversed here. A template invents keys
+ * the module never declares, so a lane on one can only be validated through its
+ * alias; a padKeys entry IS a declared param (bd_c_tune is in chain_params), so
+ * its lane validates by its own key. Mapping it back to `pad_pitch` — which the
+ * module does not declare — would make every per-voice lane look stale and get
+ * purged. */
 export function aliasFromConcrete(ps: PadScoping | undefined, key: string): string | null {
     if (!ps) return null;
     const m = templateRegex(ps.concreteKeyTemplate, ps.padDigits, '(.+)')?.exec(key);

--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -118,6 +118,11 @@ export function paramAutomatable(s: ModelState, p: KnobParam): boolean {
     if (!p.automatable) return false;
     const drum = s.moduleConfig?.drum;
     if (drum?.padScoping && drum.automatablePads && s.drumCurrentPad > drum.automatablePads) return false;
+    /* padKeys: an alias with no key on the focused pad has no target to offer,
+     * so no automation dot appears for a knob that does nothing. Gated on
+     * padKeys — this runs per knob per frame, and a template always resolves. */
+    if (drum?.padScoping?.padKeys && p.key.startsWith(drum.padScoping.aliasPrefix)
+        && paramIoKey(s, p) === p.key) return false;
     return true;
 }
 
@@ -228,7 +233,15 @@ export function reseedPadParams(s: ModelState): void {
         const p = s.knobParams[i];
         if (!p) continue;
         const ioKey = concreteKey(ps, s.drumCurrentPad, p.key);
-        if (ioKey === p.key) continue; // not pad-scoped
+        if (ioKey === p.key) {
+            if (!p.key.startsWith(ps.aliasPrefix)) continue;   // not pad-scoped
+            /* A padKeys alias with no key on this pad. Clear rather than read:
+             * the key cannot exist, so the IPC would be wasted, and keeping the
+             * previous pad's number would show a value this voice hasn't got. */
+            s.knobValues[i] = null;
+            if (p.type === 'file') s.fileValues[i] = null;
+            continue;
+        }
         const raw = s.port.getParam(s.componentKey + ':' + ioKey);
         if (p.type === 'file') {
             s.fileValues[i] = raw;

--- a/src/types/param.ts
+++ b/src/types/param.ts
@@ -116,8 +116,10 @@ export interface DrumConfig {
      * literal in code. */
     padScoping?: {
         aliasPrefix:         string;   // "pad_"
-        concreteKeyTemplate: string;   // "p{pad}_{suffix}"
-        padDigits:           number;   // 2
+        /* Template addressing: the pad NUMBER builds the key. Optional, because
+         * a padKeys-only config has no key shape to describe. */
+        concreteKeyTemplate?: string;  // "p{pad}_{suffix}"
+        padDigits?:          number;   // 2
         /* Per-suffix template overrides for params whose concrete keys follow a
          * different shape than the module's main template (Forge: sends/pan are
          * v{pad}_fx1, not pv{pad}_fx1 — only the v-form is host-automatable).
@@ -125,6 +127,20 @@ export interface DrumConfig {
          * (Forge: Kit A, 1-8); beyond it the main template applies, keeping the
          * param editable (not automatable) on the remaining pads. */
         suffixOverrides?: Record<string, { template: string; maxPad?: number }>;
+        /* TABLE addressing — the alternative to the template: each alias suffix
+         * lists its concrete key per pad, index 0 = pad 1.
+         *   padKeys: { pitch: ["bd_c_tune", "sd_c_tune", "ohh_pitch", ...] }
+         * Analog-drum modules (TR-909/606 clones) are one circuit per voice, so
+         * params are named after the VOICE and every voice has a different set —
+         * no template derives `ohh_pitch` from pad 8. Unlike the synthetic keys a
+         * template invents, these are the module's OWN declared params, so they
+         * need no alias in chain_params and automate by their own key (see
+         * aliasFromConcrete). One entry per pad; `null` means the voice has no
+         * such knob (a sampled cymbal has no Pitch Depth) — the knob then reads
+         * as unavailable and is inert, instead of showing the last pad's value.
+         * A pad past the end of the list falls back to the template, or stays
+         * unresolved when there is none. */
+        padKeys?: Record<string, (string | null)[]>;
     };
 }
 


### PR DESCRIPTION
Hi Dima — this comes straight out of your note about drum configs:

> currently it assumes that all pads have the same set of params and it expects specific naming for those parameters. I don't know if it works for 9W9 already or requires some additional work on movy side

It doesn't work for 9W9 today, and it can't — so here's the movy-side work, offered as a **second way of addressing per-pad params** that sits beside the existing one rather than replacing it.

## The gap

`padSpecific` resolves an alias to the focused pad's key through `padScoping.concreteKeyTemplate`, which builds the key from the pad **number**:

```
pad_vol + pad 3  →  p03_vol
```

That's exactly right for a sample player or a voice-cloned engine — Mr Drums, Forge, Libpo32 — where pad *N* owns an identical set of params. It bakes in two assumptions an analog-style drum machine breaks:

1. **The pad's index names its params.** A TR-909/606-style module is one circuit per voice, so params are named after the *voice*: `bd_c_tune`, `sd_c_tune`, `ohh_pitch`. No template derives `ohh_pitch` from pad 8.
2. **Every pad has the same set.** It genuinely doesn't: the kick has Sub, Tube and Drift; a sampled cymbal has no Drive or Distortion at all. And two pads can be *one* circuit with different knobs — closed and open hi-hat share `ohh_pitch` but have separate decays (`ohh_decay_closed` / `ohh_decay`).

The result is that these modules can't have a pad-following page at all. [9W9](https://github.com/athousanddetails/schwung-9W9) currently ships six static banks (Kick, Snare, Toms, Perc, Hats, Master) and you page through them with the knob-page button — the pad in your hand tells movy nothing.

The alternative would be for each such module to grow a DSP-side alias layer (`p01_pitch … p11_level` → the real keys, plus alias params in `chain_params`) purely to satisfy the key shape. That's real work per module, a wider public param surface, and it makes the DSP carry a naming convention that only exists for one host.

## What this adds

`padScoping.padKeys` — the same idea, addressed by a table instead of a template:

```json
"padScoping": {
  "aliasPrefix": "pad_",
  "padKeys": {
    "pitch": ["bd_c_tune", "sd_c_tune", "…", "ohh_pitch"],
    "drive": ["bd_c_drive", "sd_c_drive", "…", null]
  }
}
```

`pad_pitch` on pad 8 → `ohh_pitch`. A `null` says *this voice hasn't got that knob*: the knob reads as unavailable (`...`), writes nothing, and shows no automation dot — instead of displaying the previous pad's value and writing to a key that doesn't exist.

Both forms live in the same two pure functions in `model/pad-scope.ts`, so **every** existing caller — I/O key, reseed on pad change, automation lane resolution, lane validation — works unchanged, and they compose: the table wins where it lists a suffix, the template covers the rest.

## Two decisions worth reviewing

**`padKeys` entries are deliberately not reverse-mapped in `aliasFromConcrete`.** A template invents keys the module never declares, so a lane on one can only be validated through its alias. A `padKeys` entry is the opposite: `bd_c_tune` *is* in `chain_params`, so its lane validates by its own name. Mapping it back to `pad_pitch` — a key the module never declares — would make every per-voice lane look stale and get purged. The asymmetry is the point, and it's commented at both sites.

**A listed `null` doesn't fall through to the template.** It's a declaration, not a gap; falling back would address a key the module never had.

Consequence worth flagging: `concreteKeyTemplate` and `padDigits` are now optional (a `padKeys`-only config has no key shape to describe). Existing configs are untouched and typecheck clean.

## Behaviour for existing modules

None changes. Every config in `src/modules/` and both fixture layouts still take the template path; `dump-replay` replays all 79 modules with their snapshots intact, and the 133 screenshot baselines are unchanged.

## Tests

- `logic/drums.mjs` — unit cases for the table, `null`, pad-past-list, and table-vs-template precedence; plus a model-level suite on a real heterogeneous module (9W9): per-voice addressing and values, a knob turn writing `bd_c_tune` and never the alias, pads 8/9 sharing one circuit with different decay keys, and the absent-param path (unavailable → inert → no dot → live again on a pad that has it).
- `logic/automation.mjs` — the reverse-mapping asymmetry and `validateLane` keeping a per-voice lane while still dropping a bare alias.
- `browser-test/fixtures/9w9-movy-config.json` — 9W9's real layout with the pad-following bank added, served like the Forge fixture.

`npm run typecheck` clean. `logic`, `dump-replay` (79 modules), `app-loop`, `screenshot` (133/133), `perf`, `device-scripts` all pass. **`track-colors` and `abi-parity` could not run here** — both hardcode `/Users/dake/git/cld/schwung/...`, so `npm test` exits at `abi-parity` on any machine but yours; you may want those two paths behind an env var so outside contributors can run the suite to the end. No device e2e: my Move is on Schwung 0.12.1 with 9W9, so I can test on hardware if you'd like a specific check.

The extra work in the hot path is one property lookup per knob per frame (the absent-param automation guard is gated on `padKeys` being present), and an absent param costs *zero* IPC on a pad change instead of a wasted read. `perf` is green.

## Follow-up, not in this PR

If this lands, 9W9 ships the config in the same shape — one `Voice` bank that follows the pad with Pitch / Decay / Drive / Dist / Level — and I'm happy to send the 606 and 909 templates you mentioned in the same form if you want them bundled.

Per CONTRIBUTING: this was written with AI assistance (Claude), with the design decisions, the review and every test run driven by hand. Happy to split, rename (`padKeys` vs something you prefer), or rework the null semantics if you'd rather have a stricter contract.
