### PR TITLE
drums: a bank can name the pad that selects it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,11 @@ click; here that opens the module browser, so the gesture moved to Shift.)
 Without the flag, Shift + jog click keeps doing exactly what it does today —
 no module spends a gesture it did not ask to.
 
+> Worth a line in your own module's docs: schwung's on-device editor locks with
+> a **plain** jog click, Movy needs **Shift**, because a plain click here opens
+> the module browser. A user who learns the gesture on the device will try it in
+> Movy, get nothing, and report the feature broken.
+
 For modules whose releases Movy explicitly supports, copy the released
 `module.json` into `browser-test/fixtures/module-contracts/` using the
 `<component-type>--<module-id>.json` name. Contract fixtures replace an older

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,10 +179,19 @@ the silence and the page move are decided separately.
 The two mechanisms are independent: use `padSpecific` for one following bank,
 `pad` for a page per voice, or neither.
 
-**Shift + jog click** on the params page locks pad-follow: pads still play, but
-they stop turning the page, so the knobs you are working on stay put. Toggles,
-with a toast either way. (schwung's own editor locks with a plain jog click;
-here that opens the module browser, so the gesture moved to Shift.)
+Opt in to the lock gesture with `"padFollowLock": true` in the `drum` block:
+
+```json
+"drum": { "padCount": 16, "padNoteStart": 36, "rawMidi": false,
+          "padFollowLock": true }
+```
+
+**Shift + jog click** on the params page then locks pad-follow: pads still
+play, but they stop turning the page, so the knobs you are working on stay put.
+Toggles, with a toast either way. (schwung's own editor locks with a plain jog
+click; here that opens the module browser, so the gesture moved to Shift.)
+Without the flag, Shift + jog click keeps doing exactly what it does today —
+no module spends a gesture it did not ask to.
 
 For modules whose releases Movy explicitly supports, copy the released
 `module.json` into `browser-test/fixtures/module-contracts/` using the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,11 @@ the silence and the page move are decided separately.
 The two mechanisms are independent: use `padSpecific` for one following bank,
 `pad` for a page per voice, or neither.
 
+**Shift + jog click** on the params page locks pad-follow: pads still play, but
+they stop turning the page, so the knobs you are working on stay put. Toggles,
+with a toast either way. (schwung's own editor locks with a plain jog click;
+here that opens the module browser, so the gesture moved to Shift.)
+
 For modules whose releases Movy explicitly supports, copy the released
 `module.json` into `browser-test/fixtures/module-contracts/` using the
 `<component-type>--<module-id>.json` name. Contract fixtures replace an older

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,25 +179,6 @@ the silence and the page move are decided separately.
 The two mechanisms are independent: use `padSpecific` for one following bank,
 `pad` for a page per voice, or neither.
 
-Opt in to the lock gesture with `"padFollowLock": true` in the `drum` block:
-
-```json
-"drum": { "padCount": 16, "padNoteStart": 36, "rawMidi": false,
-          "padFollowLock": true }
-```
-
-**Shift + jog click** on the params page then locks pad-follow: pads still
-play, but they stop turning the page, so the knobs you are working on stay put.
-Toggles, with a toast either way. (schwung's own editor locks with a plain jog
-click; here that opens the module browser, so the gesture moved to Shift.)
-Without the flag, Shift + jog click keeps doing exactly what it does today —
-no module spends a gesture it did not ask to.
-
-> Worth a line in your own module's docs: schwung's on-device editor locks with
-> a **plain** jog click, Movy needs **Shift**, because a plain click here opens
-> the module browser. A user who learns the gesture on the device will try it in
-> Movy, get nothing, and report the feature broken.
-
 For modules whose releases Movy explicitly supports, copy the released
 `module.json` into `browser-test/fixtures/module-contracts/` using the
 `<component-type>--<module-id>.json` name. Contract fixtures replace an older

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,34 @@ keys, which are synthetic and validate through their alias. Both forms may
 appear in one config: the table wins where it lists a suffix, the template
 covers the rest.
 
+### A pad that selects a whole page
+
+`padSpecific` re-points ONE bank at the pad you press. That fits a kit whose
+pads share a control set. It does not fit a machine whose voices are separate
+circuits with different panels — a 909's snare has no Decay or Attack and its
+kick has no FX sends, so a single re-targeting row is mostly holes. Such a
+module wants a page *per* voice, and the pad to choose among them, the way
+schwung's stock editor switches page to the drum you hit.
+
+For that, a bank names the pad that selects it:
+
+```json
+"banks": [
+  { "name": "Main",  "rows": [ ... ] },
+  { "name": "Kick",  "pad": 1, "rows": [ ... ] },
+  { "name": "Snare", "pad": 2, "rows": [ ... ] }
+]
+```
+
+Pad numbers are 1-based, like everywhere else in the drum API. A bank with no
+`pad` is never auto-selected — that is how a page stays off the rotation (Main
+here, or an FX page) — and an unclaimed pad leaves the page where it is rather
+than guessing. **Shift+Pad** selects the page without sounding the voice, since
+the silence and the page move are decided separately.
+
+The two mechanisms are independent: use `padSpecific` for one following bank,
+`pad` for a page per voice, or neither.
+
 For modules whose releases Movy explicitly supports, copy the released
 `module.json` into `browser-test/fixtures/module-contracts/` using the
 `<component-type>--<module-id>.json` name. Contract fixtures replace an older

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -713,6 +713,22 @@ pages instead of a page per voice. *Signal* (4 voices) works this way:
 
 ![Pad-selected voice page](docs/assets/signal_voice.png)
 
+A drum machine whose voices are separate circuits — a TR-909 or TR-606 style
+kit, where the snare has no Attack and the kick has no FX sends — does the
+opposite: a **page per voice**, with the pad choosing among them. Press the
+snare pad and the screen goes to the snare's page, exactly as schwung's own
+editor does. **Shift + pad** goes there without sounding the voice. Pads that
+have no voice behind them (a spare pad in the grid) can open a page too — 9W9
+puts Main, Reverb and Delay on three of them.
+
+> **The lock gesture differs between Movy and the on-device editor, and this
+> catches people out.** Schwung's stock editor freezes the page with a **plain
+> jog click**. In Movy a plain jog click opens the module browser, so the lock
+> is **Shift + jog click** on the params page. Learn it on the device, try it
+> here, and it will look broken. Locked, the pads still play — they just stop
+> turning the page, so the knobs you are editing stay put. Modules opt in, so
+> the gesture does nothing on a module that has not asked for it.
+
 *Sample Slicer* is a slice player rather than a kit: its **32 pads are the 32
 slices** the module can trigger (pad 1 = slice 1). Its Main page carries the
 **Sample** browser — hold that knob and click the jog to browse

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -721,14 +721,6 @@ editor does. **Shift + pad** goes there without sounding the voice. Pads that
 have no voice behind them (a spare pad in the grid) can open a page too — 9W9
 puts Main, Reverb and Delay on three of them.
 
-> **The lock gesture differs between Movy and the on-device editor, and this
-> catches people out.** Schwung's stock editor freezes the page with a **plain
-> jog click**. In Movy a plain jog click opens the module browser, so the lock
-> is **Shift + jog click** on the params page. Learn it on the device, try it
-> here, and it will look broken. Locked, the pads still play — they just stop
-> turning the page, so the knobs you are editing stay put. Modules opt in, so
-> the gesture does nothing on a module that has not asked for it.
-
 *Sample Slicer* is a slice player rather than a kit: its **32 pads are the 32
 slices** the module can trigger (pad 1 = slice 1). Its Main page carries the
 **Sample** browser — hold that knob and click the jog to browse

--- a/browser-test/app-loop.mjs
+++ b/browser-test/app-loop.mjs
@@ -208,6 +208,45 @@ _log('\napp-loop: drum pads + step lane stay live on a non-synth module slot');
     eq('FX slot focused: selected drum pad lights white', padColor(PAD_SNARE), 120);
 }
 
+_log('\napp-loop: a pad press turns the page (bank.pad, through the router)');
+{
+    /* The logic suite calls selectBankForPad() directly; this covers the
+     * router hookup — a real pad note-on arriving at onMidiMessageInternal
+     * has to move the page. Served as a module-owned layout, the way a kit
+     * with a page per voice ships it. */
+    const layout = JSON.stringify({
+        id: 'mrdrums', name: 'MrDrums',
+        drum: { padCount: 16, padNoteStart: 36, rawMidi: false },
+        banks: [
+            { name: 'Main', rows: [[{ key: 'pad_vol', short: 'VOL', full: 'Volume',
+                                      type: 'float', min: 0, max: 2 }]] },
+            { name: 'Kick',  pad: 1, rows: [[{ key: 'pad_vol', short: 'VOL', full: 'Volume',
+                                               type: 'float', min: 0, max: 2 }]] },
+            { name: 'Snare', pad: 2, rows: [[{ key: 'pad_vol', short: 'VOL', full: 'Volume',
+                                               type: 'float', min: 0, max: 2 }]] },
+        ],
+    });
+    const savedRead = globalThis.host_read_file;
+    globalThis.host_read_file = (p) =>
+        String(p).endsWith('/mrdrums/movy_config.json') ? layout : (savedRead ? savedRead(p) : null);
+    resetApp();
+    globalThis.host_read_file = savedRead;
+
+    const model = appState.trackModels[0][1];
+    eq('opens on the bank no pad claims', model.getKnobPage(), 0);
+
+    const PAD_SNARE = 69;                    // grid pad 2 → drumPad 2
+    sendMidi([0x90, PAD_SNARE, 100]);
+    sendMidi([0x80, PAD_SNARE, 0]);
+    advance(2);
+    eq('a pad note-on selects that pad\'s bank', model.getKnobPage(), 2);
+
+    sendMidi([0x90, PAD_KICK, 100]);
+    sendMidi([0x80, PAD_KICK, 0]);
+    advance(2);
+    eq('and another pad moves it again', model.getKnobPage(), 1);
+}
+
 _log('\napp-loop: green wins over white (sequencer gate)');
 {
     resetApp();

--- a/browser-test/logic/drums.mjs
+++ b/browser-test/logic/drums.mjs
@@ -425,6 +425,84 @@ _log('\nTest: weird-dreams per-voice scoping');
   eq('ioKey follows focus to v3_vol', wd.getKnobParamInfo(0).ioKey, 'v3_vol');
 }
 
+/* ── Pad-follow: a pad selects the bank that declares it ──────────────────── */
+
+_log('\nTest: bank.pad — a pad press selects that bank');
+
+{
+  /* A voice-per-page kit: pages 1..3 are claimed by pads 1..3, page 0 (Main)
+   * by nobody. Mirrors 9W9's real layout without depending on its fixture. */
+  const layout = JSON.stringify({
+    id: 'padbank', name: 'PadBank',
+    drum: { padCount: 4, padNoteStart: 36, rawMidi: false },
+    banks: [
+      { name: 'Main',  rows: [[{ key: 'volume', short: 'VOL', full: 'Volume', type: 'int', min: 0, max: 127 }]] },
+      { name: 'Kick',  pad: 1, rows: [[{ key: 'bd_tune', short: 'TUNE', full: 'Tune', type: 'int', min: 0, max: 127 }]] },
+      { name: 'Snare', pad: 2, rows: [[{ key: 'sd_tune', short: 'TUNE', full: 'Tune', type: 'int', min: 0, max: 127 }]] },
+      { name: 'Hat',   pad: 3, rows: [[{ key: 'hh_tune', short: 'TUNE', full: 'Tune', type: 'int', min: 0, max: 127 }]] },
+    ],
+  });
+  const savedRead = globalThis.host_read_file;
+  globalThis.host_read_file = (p) => p.endsWith('/padbank/movy_config.json') ? layout : null;
+  const m = bootModel({ 'synth:name': 'PadBank', 'synth_module': 'padbank',
+                        'synth:volume': '64', 'synth:bd_tune': '10',
+                        'synth:sd_tune': '20', 'synth:hh_tune': '30' }, 0, 'synth');
+  globalThis.host_read_file = savedRead;
+
+  eq('opens on Main (page 0)', m.getKnobPage(), 0);
+
+  m.selectBankForPad(2);
+  eq('pad 2 selects Snare', m.getKnobPage(), 2);
+  eq('and the knob is the snare param', m.getKnobParamInfo(0)?.ioKey, 'sd_tune');
+
+  m.selectBankForPad(1);
+  eq('pad 1 selects Kick', m.getKnobPage(), 1);
+
+  /* No bank claims pad 4 — the page must not move. Falling back to a
+   * positional guess would drag the user off the page they are editing. */
+  m.selectBankForPad(4);
+  eq('unclaimed pad leaves the page alone', m.getKnobPage(), 1);
+
+  /* Re-selecting the page you are on is not a change (no needless redraw). */
+  m.selectBankForPad(1);
+  eq('re-selecting the same bank is a no-op', m.getKnobPage(), 1);
+}
+
+_log('\nTest: bank.pad — absent from a config, nothing follows');
+
+{
+  /* mrdrums declares no `pad` anywhere: every existing config must behave
+   * exactly as it did before this feature. */
+  const m = bootModel(MRDRUMS_PRESET, 0, 'synth');
+  const before = m.getKnobPage();
+  m.selectBankForPad(1);
+  m.selectBankForPad(3);
+  eq('no bank.pad → page unchanged', m.getKnobPage(), before);
+}
+
+_log('\nTest: bank.pad — shift+pad selects silently');
+
+{
+  /* The silence is drumPadOn's call (suppressMidi), and the page move is the
+   * model's; together they make Shift+Pad a silent page change. Asserted as
+   * one gesture so the pair cannot drift apart. */
+  const cfg = { padCount: 4, padNoteStart: 36, rawMidi: false };
+  let sent = [];
+  const origSend = globalThis.shadow_send_midi_to_dsp;
+  globalThis.shadow_send_midi_to_dsp = (msg) => { sent.push([...msg]); };
+
+  const padShift = drumPadOn(69, 68, true, cfg, 'synth', 0, 100);
+  eq('shift+pad sounds nothing', sent.length, 0);
+  eq('shift+pad still resolves a pad', padShift, 2);
+
+  sent = [];
+  const padPlain = drumPadOn(69, 68, false, cfg, 'synth', 0, 100);
+  eq('plain pad does sound', sent.length > 0, true);
+  eq('plain pad resolves the same pad', padPlain, 2);
+
+  globalThis.shadow_send_midi_to_dsp = origSend;
+}
+
 /* ── 9W9: per-voice keys via padKeys ─────────────────────────────────────── */
 
 _log('\nTest: 9w9 padKeys per-pad addressing');

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -40,10 +40,6 @@ export const appState = {
     focusGroup:       0,
     currentView:      VIEW_CHAIN,
     shiftHeld:        false,
-    /* Pad-follow lock (Shift + jog click on the params page). While set, a pad
-     * still plays its voice but no longer turns the page, so the knobs you are
-     * working on stay under your hands. Session state, not persisted. */
-    padFollowLocked:  false,
     dirty:            true,
     initLedIndex:     0,
     initLedsDone:     false,

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -40,6 +40,10 @@ export const appState = {
     focusGroup:       0,
     currentView:      VIEW_CHAIN,
     shiftHeld:        false,
+    /* Pad-follow lock (Shift + jog click on the params page). While set, a pad
+     * still plays its voice but no longer turns the page, so the knobs you are
+     * working on stay under your hands. Session state, not persisted. */
+    padFollowLocked:  false,
     dirty:            true,
     initLedIndex:     0,
     initLedsDone:     false,

--- a/src/lfo/model.ts
+++ b/src/lfo/model.ts
@@ -149,6 +149,9 @@ export function createScopedLfoModel(scope: LfoScope): Model {
             const next = clampI(bank + delta, 0, LFO_BANK_COUNT - 1);
             if (next !== bank) { bank = next; touched.length = 0; dirty = true; }
         },
+        /* The LFO page's banks are its own fixed set, not a module config, so
+         * no pad claims one. Present to satisfy the shared model shape. */
+        selectBankForPad(_pad: number): void {},
         getModuleName(): string { return 'LFO'; },
         reset(): void { bank = 0; touched.length = 0; overlay = null; accum.fill(0); loaded = false; dirty = true; },
         // Values are movy-owned once loaded; they are read from shadow only on

--- a/src/midi/router.ts
+++ b/src/midi/router.ts
@@ -314,7 +314,12 @@ export function onMidiMessageInternal(data: number[]): void {
             const vel = seqState.fullVelocity ? 127 : d2;
             if (drumCfg) {
                 const pad = drumPadOn(d1, PAD_MIN, appState.shiftHeld, drumCfg, model!.getComponentKey(), track, vel);
-                if (pad !== null) model!.updateDrumPad(pad, d1);
+                if (pad !== null) {
+                    model!.updateDrumPad(pad, d1);
+                    /* Pad-follow, for configs that declare `pad` on a bank. A
+                     * no-op for every config that does not. */
+                    model!.selectBankForPad(pad);
+                }
             } else {
                 noteOn(d1, PAD_MIN, track, vel);
             }

--- a/src/midi/router.ts
+++ b/src/midi/router.ts
@@ -317,10 +317,8 @@ export function onMidiMessageInternal(data: number[]): void {
                 if (pad !== null) {
                     model!.updateDrumPad(pad, d1);
                     /* Pad-follow, for configs that declare `pad` on a bank. A
-                     * no-op for every config that does not, and skipped while
-                     * the page is locked — the pad still sounds, it just stops
-                     * moving the page out from under you. */
-                    if (!appState.padFollowLocked) model!.selectBankForPad(pad);
+                     * no-op for every config that does not. */
+                    model!.selectBankForPad(pad);
                 }
             } else {
                 noteOn(d1, PAD_MIN, track, vel);
@@ -585,22 +583,6 @@ export function onMidiMessageInternal(data: number[]): void {
                     appState.currentView = VIEW_KNOBS;
                     appState.dirty = true;
                 }
-            } else if (appState.shiftHeld && synthModel()?.getDrumConfig()?.padFollowLock) {
-                /* Shift + jog click on the params page: lock pad-follow.
-                 *
-                 * schwung's own editor locks with a plain jog click, which is
-                 * not free here — a click opens the module browser. Shift+click
-                 * on this page was doing the same as a plain click (unlike the
-                 * chain views, which already read Shift), so it is the gesture
-                 * with nothing to lose.
-                 *
-                 * Opt-in: without `drum.padFollowLock` this branch does not
-                 * exist and Shift+click falls through to the browser exactly as
-                 * before, so no module loses a gesture it did not ask to spend.
-                 * Read from the SYNTH slot like every other drum question. */
-                appState.padFollowLocked = !appState.padFollowLocked;
-                seqToast(appState.padFollowLocked ? 'Pads locked' : 'Pads unlocked');
-                appState.dirty = true;
             } else if (!isLfoSlot(chainIndex())) {
                 // VIEW_KNOBS with no file param held → module browser (the LFO
                 // slot has no module to swap, so a click is a no-op there).

--- a/src/midi/router.ts
+++ b/src/midi/router.ts
@@ -317,8 +317,10 @@ export function onMidiMessageInternal(data: number[]): void {
                 if (pad !== null) {
                     model!.updateDrumPad(pad, d1);
                     /* Pad-follow, for configs that declare `pad` on a bank. A
-                     * no-op for every config that does not. */
-                    model!.selectBankForPad(pad);
+                     * no-op for every config that does not, and skipped while
+                     * the page is locked — the pad still sounds, it just stops
+                     * moving the page out from under you. */
+                    if (!appState.padFollowLocked) model!.selectBankForPad(pad);
                 }
             } else {
                 noteOn(d1, PAD_MIN, track, vel);
@@ -583,6 +585,17 @@ export function onMidiMessageInternal(data: number[]): void {
                     appState.currentView = VIEW_KNOBS;
                     appState.dirty = true;
                 }
+            } else if (appState.shiftHeld) {
+                /* Shift + jog click on the params page: lock pad-follow.
+                 *
+                 * schwung's own editor locks with a plain jog click, which is
+                 * not free here — a click opens the module browser. Shift+click
+                 * on this page was doing the same as a plain click (unlike the
+                 * chain views, which already read Shift), so it is the gesture
+                 * with nothing to lose. */
+                appState.padFollowLocked = !appState.padFollowLocked;
+                seqToast(appState.padFollowLocked ? 'Pads locked' : 'Pads unlocked');
+                appState.dirty = true;
             } else if (!isLfoSlot(chainIndex())) {
                 // VIEW_KNOBS with no file param held → module browser (the LFO
                 // slot has no module to swap, so a click is a no-op there).

--- a/src/midi/router.ts
+++ b/src/midi/router.ts
@@ -585,14 +585,19 @@ export function onMidiMessageInternal(data: number[]): void {
                     appState.currentView = VIEW_KNOBS;
                     appState.dirty = true;
                 }
-            } else if (appState.shiftHeld) {
+            } else if (appState.shiftHeld && synthModel()?.getDrumConfig()?.padFollowLock) {
                 /* Shift + jog click on the params page: lock pad-follow.
                  *
                  * schwung's own editor locks with a plain jog click, which is
                  * not free here — a click opens the module browser. Shift+click
                  * on this page was doing the same as a plain click (unlike the
                  * chain views, which already read Shift), so it is the gesture
-                 * with nothing to lose. */
+                 * with nothing to lose.
+                 *
+                 * Opt-in: without `drum.padFollowLock` this branch does not
+                 * exist and Shift+click falls through to the browser exactly as
+                 * before, so no module loses a gesture it did not ask to spend.
+                 * Read from the SYNTH slot like every other drum question. */
                 appState.padFollowLocked = !appState.padFollowLocked;
                 seqToast(appState.padFollowLocked ? 'Pads locked' : 'Pads unlocked');
                 appState.dirty = true;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -275,6 +275,26 @@ export function createModel(port: TrackPort, componentKey = 'synth') {
             if (next !== s.knobPage) { s.knobPage = next; s.dirty = true; }
         },
 
+        /* Pad-follow: select the bank that declares this pad.
+         *
+         * Silent by construction for a shift-select — the caller has already
+         * decided whether the pad sounds; choosing the page is the same either
+         * way, which is what makes Shift+Pad a silent page change.
+         *
+         * No bank claims the pad -> nothing moves. That is the documented way
+         * to keep a page (Main, an FX page) out of the rotation, so it must not
+         * fall back to a positional guess. */
+        selectBankForPad(pad: number): void {
+            if (s.enumOverlay) return;
+            const banks = s.moduleConfig?.banks;
+            if (!banks) return;
+            const next = banks.findIndex(b => b.pad === pad);
+            if (next < 0 || next === s.knobPage) return;
+            mlog('selectBankForPad pad=' + pad + ' ' + s.knobPage + '→' + next);
+            s.knobPage = next;
+            s.dirty = true;
+        },
+
         /* Shift+jog: jump to the head of the previous/next level. From mid-level
          * a backward jump lands on the current level's own head first — the same
          * "back out to the section start" feel as a paragraph jump. */

--- a/src/types/param.ts
+++ b/src/types/param.ts
@@ -123,6 +123,12 @@ export interface DrumConfig {
     rawMidi:          boolean;
     currentPadParam?: string;
     shiftSelectMidi?: boolean;
+    /* Offer the pad-follow lock gesture (Shift + jog click on the params page):
+     * pads keep playing but stop turning the page, so the knobs you are editing
+     * stay put. Opt-in, because it spends a gesture — without it, Shift + jog
+     * click keeps doing exactly what it does today. Only meaningful alongside
+     * `pad` on the banks; a module with no pad-follow has nothing to lock. */
+    padFollowLock?: boolean;
     /* Only pads 1..N are host-automatable (the chain caps declared params at 256,
      * so a padScoped module can only declare concrete keys for some voices —
      * Forge: Kit A pv1-8). A param on a pad past this is not offered for

--- a/src/types/param.ts
+++ b/src/types/param.ts
@@ -123,12 +123,6 @@ export interface DrumConfig {
     rawMidi:          boolean;
     currentPadParam?: string;
     shiftSelectMidi?: boolean;
-    /* Offer the pad-follow lock gesture (Shift + jog click on the params page):
-     * pads keep playing but stop turning the page, so the knobs you are editing
-     * stay put. Opt-in, because it spends a gesture — without it, Shift + jog
-     * click keeps doing exactly what it does today. Only meaningful alongside
-     * `pad` on the banks; a module with no pad-follow has nothing to lock. */
-    padFollowLock?: boolean;
     /* Only pads 1..N are host-automatable (the chain caps declared params at 256,
      * so a padScoped module can only declare concrete keys for some voices —
      * Forge: Kit A pv1-8). A param on a pad past this is not offered for

--- a/src/types/param.ts
+++ b/src/types/param.ts
@@ -80,6 +80,23 @@ export interface BankConfig {
     name: string;
     rows: (KnobSlot | null)[][];
     padSpecific?: boolean;
+    /* Pad-follow: pressing this pad selects this bank, the way schwung's stock
+     * editor switches page to the drum you hit.
+     *
+     * The alternative already here is `padSpecific` — ONE bank whose alias keys
+     * re-target to the focused pad. That fits a kit whose pads share a control
+     * set. It does not fit an analog-style drum machine, where the voices are
+     * different circuits: a 909's snare has no Decay or Attack, its kick has no
+     * FX sends, so a single re-targeting row is mostly holes. Such a module
+     * wants a page PER voice, and the pad to choose among them.
+     *
+     * Opt-in and per bank. A bank without `pad` is never auto-selected (that is
+     * how a module keeps Main, or an FX page, off the pad rotation), and a
+     * config that sets it nowhere behaves exactly as before.
+     *
+     * 1-based, like every other pad number movy hands around (drumPadOn returns
+     * 1 for the first pad, and padKeys indexes `table[pad - 1]`). */
+    pad?: number;
     /* Params in this bank are non-automatable globals (not reachable as a chain
      * target:param). Replaces the old `g_` key-prefix heuristic. */
     global?: boolean;


### PR DESCRIPTION
Hi Dima — a follow-on from #15, and the other half of what an analog-style drum machine needs from Movy.

Two additions, both opt-in, both no-ops for every module that does not ask for them.

## The gap

`padSpecific` re-points **one** bank at the pad you press. That is right for a kit whose pads share a control set — a sample player, a voice-cloned engine.

It is the wrong shape for a machine whose voices are separate circuits with different panels. On a TR-909 the snare has no Decay and no Attack, the rim has neither, and the kick deliberately has no FX sends. Put those on one re-targeting row and most of it is holes, on most pads. What such a module wants is a page **per voice**, with the pad choosing among them — which is exactly what schwung's own editor does: hit a drum, the page follows.

There is no way to express that today. `changePage`/`changePageGroup` move by a delta, nothing maps a pad to a bank, and a pad press ends at `updateDrumPad`.

## 1. A bank can name the pad that selects it

```json
"banks": [
  { "name": "Main",  "rows": [ ... ] },
  { "name": "Kick",  "pad": 1, "rows": [ ... ] },
  { "name": "Snare", "pad": 2, "rows": [ ... ] }
]
```

Pad numbers are **1-based**, matching `drumPadOn`'s return and `padKeys`' `table[pad - 1]`. (Worth stating loudly: I shipped a 0-based config on the 9W9 side first and every pad selected the wrong drum's page.)

Three deliberate behaviours, each with a test:

- **A bank without `pad` is never auto-selected.** That is how a module keeps a page off the rotation — Main above, or an FX page.
- **An unclaimed pad leaves the page alone**, rather than falling back to a positional guess. Being dragged off the page you are editing because you tapped a pad nothing claims is worse than nothing happening.
- **Re-selecting the current page is not a change**, so no needless redraw.

**Shift+Pad selects silently and needed no code.** `drumPadOn` already decides whether a pad sounds (`suppressMidi`); the page move is the model's. They compose. There is a test asserting the pair in one place so they cannot drift apart later.

## 2. An opt-in lock for the gesture

Pad-follow is right until you are actually editing: reach for a pad to hear what you just changed, and the page you were working on is gone.

schwung's editor solves this with a plain jog click on the main page. That gesture is not free here — a click on the params page opens the module browser. Shift+click on **that page** was doing exactly the same as a plain click (unlike the chain views, which already read Shift), so it is the gesture with nothing to lose.

Opt in per module:

```json
"drum": { "padCount": 16, "padNoteStart": 36, "rawMidi": false,
          "padFollowLock": true }
```

**Shift + jog click** on the params page then toggles the lock: pads keep playing, they just stop turning the page. Toast either way, so the state is visible without a persistent glyph — which is also why the 138 screenshot baselines are untouched. Session state, not persisted. Without the flag the branch does not exist and Shift + jog click behaves exactly as it does today, so no module spends a gesture it did not ask to.

## What a module developer has to do

Nothing movy-side. No bundled entry, no key table, no code.

1. Add `"pad": N` to each bank that a pad should select — 1-based, in drum-rack order. Movy pad `N` is MIDI note `padNoteStart + N - 1`.
2. Leave `pad` off any bank that should stay off the rotation (a master page, a settings page).
3. Optionally add `"padFollowLock": true` to the `drum` block for the lock gesture.

A page-only pad is worth knowing about: on 9W9 pads 12, 15 and 16 select Main, Reverb and Delay. Those sit past the kit's note range (36–46), so pressing one sounds nothing and only turns the page — the same seats and the same feel as the stock editor. Nothing special is needed to get that; the pad simply has no voice behind it.

`CONTRIBUTING.md` documents both, next to the existing `padSpecific` / `padScoping` section.

## Scope and compatibility

Both features are opt-in and absent from every existing config, so nothing moves: `dump-replay` covers all 80 modules and the 138 screenshot baselines are unchanged.

The LFO page implements the same model shape, so it gets an explicit no-op with a comment — its banks are its own fixed set and no pad claims one.

## Testing

Automated — `browser-test/logic/drums.mjs`: bank selection by pad, an unclaimed pad, the same-bank no-op, a config with no `pad` anywhere (mrdrums, unchanged), and the shift gesture sounding nothing while still resolving a pad.

`npm run typecheck` clean. `logic`, `dump-replay` (80 modules), `app-loop`, `screenshot` (138/138), `perf`, `device-scripts` all pass.

**`track-colors` and `abi-parity` still hardcode `/Users/dake/git/cld/schwung/...`**, so `npm test` cannot run to the end on any machine but yours — same note as #15, and still worth an env var if you want outside contributors to complete the suite.

**On hardware.** This was developed against a real Move, not just the browser harness. A device build of this branch has been running on a Move with 9W9 (11 voices, 14 pages) throughout: pads select their drum's page, the three page-only pads open Main / Reverb / Delay, Shift+Pad selects without sounding, and the jog still pages by hand. The 1-based bug above was caught that way and not by the tests. The module author has confirmed the pad-follow behaviour on the device; the lock gesture is on the same build and being exercised now.

## Who this is for

9W9 ships the matching config (one bank per voice, each naming its pad, Main first, `padFollowLock` on). But the point is not 9W9 — any module with a page per sound gets stock-editor pad-following by adding one field per bank. 6W6, 8W8 and CW-78 are the immediate next ones and are already being updated.

Happy to rename either field, or to gate pad-follow behind a `drum.padSelectsBank` flag rather than inferring it from the banks, if you would rather it were declared once at the top.

Per CONTRIBUTING: written with AI assistance (Claude), with the design decisions, the review and every test run driven by hand.
